### PR TITLE
Add optional area code override for relay creation

### DIFF
--- a/app/commands/create.rb
+++ b/app/commands/create.rb
@@ -3,7 +3,7 @@ require_relative 'abstract_command'
 class Create < AbstractCommand
   def execute
     if sender.admin
-      new_relay_number = BuysSimilarNumbers.new(relay.number, application_url).buy_similar_number
+      new_relay_number = similar_number_buyer.buy_similar_number
       new_relay = Relay.create(name: arguments, number: new_relay_number)
       Subscription.create(relay: new_relay, subscriber: sender)
 
@@ -12,5 +12,22 @@ class Create < AbstractCommand
       NonAdminBounceResponse.new(context).deliver(sender)
       NonAdminBounceNotification.new(context).deliver relay.admins
     end
+  end
+
+  private
+  def similar_number_buyer
+    if area_code
+      BuysSimilarNumbers.new(relay.number, application_url, area_code)
+    else
+      BuysSimilarNumbers.new(relay.number, application_url)
+    end
+  end
+
+  def name
+    arguments.split.first
+  end
+
+  def area_code
+    arguments.split[1]
   end
 end

--- a/features/multirelay.feature
+++ b/features/multirelay.feature
@@ -27,3 +27,13 @@ Feature: Multi-relay
     Then I should see that relay B has number 123
     And I should see that Alice is subscribed to relay B
     But I should not see that Bob is subscribed to relay B
+
+  Scenario: Create a relay with a specified area code
+    Given the number buyer will buy number 123
+    And I am subscribed to relay A as an admin as Alice
+
+    And someone is subscribed to relay A as Bob
+    And Alice txts '/create B 500'
+
+    Then Alice should receive a txt that a relay was created from 123
+    And the number buyer should have bought a number from area code 500

--- a/features/step_definitions/relay_steps.rb
+++ b/features/step_definitions/relay_steps.rb
@@ -1,3 +1,10 @@
 Given(/^the number buyer will buy number (\d+)$/) do |number|
   BuysNumbers.stubs(:buy_number).returns(number)
 end
+
+Then(/^the number buyer should have bought a number from area code (\d+)$/) do |area_code|
+  buy_number_invocations = Mocha::Mockery.instance.invocations.select{|invocation| invocation.method_name == :buy_number}
+  invocation_area_codes = buy_number_invocations.map{|invocation| invocation.arguments.first }
+
+  expect(invocation_area_codes).to eq([area_code])
+end

--- a/lib/buys_similar_numbers.rb
+++ b/lib/buys_similar_numbers.rb
@@ -1,13 +1,14 @@
 class BuysSimilarNumbers
-  def initialize(number, url)
+  def initialize(number, url, overridden_area_code = nil)
     @number = number
     @url = url
+    @overridden_area_code = overridden_area_code
   end
 
   def buy_similar_number
     parser = ParsesNumbers.new(existing_number)
     parser.parse
-    BuysNumbers.buy_number(parser.area_code, parser.country, url)
+    BuysNumbers.buy_number(@overridden_area_code || parser.area_code, parser.country, url)
   end
 
   private

--- a/spec/commands/create_spec.rb
+++ b/spec/commands/create_spec.rb
@@ -37,6 +37,31 @@ describe Create do
 
       execute
     end
+
+    context 'with an area code' do
+      let(:arguments) { 'otherareacodename 500' }
+
+      it 'buys a similar-ish number but from a different area code' do
+        expect(BuysSimilarNumbers).to receive(:new).with(relay.number, command_context.application_url, '500').and_return(double('buyer', buy_similar_number: new_relay_number))
+
+        # FIXME This duplication seems suspect when the above is all that changed
+        relay_repository = double('relay repository')
+        stub_const('Relay', relay_repository)
+        relay = double('relay', name: arguments)
+
+        expect(relay_repository).to receive(:create).with(name: arguments, number: new_relay_number).and_return(relay)
+
+        subscription_repository = double('subscription repository')
+        stub_const('Subscription', subscription_repository)
+
+        expect(subscription_repository).to receive(:create).with(relay: relay, subscriber: sender)
+
+        expect(relay).to receive(:admins).and_return(new_relay_admins = double)
+        expect_notification_of new_relay_admins, 'CreationNotification'
+
+        execute
+      end
+    end
   end
 
   it 'replies with the non-admin message' do

--- a/spec/lib/buys_similar_numbers_spec.rb
+++ b/spec/lib/buys_similar_numbers_spec.rb
@@ -17,4 +17,14 @@ describe BuysSimilarNumbers do
 
     expect(BuysSimilarNumbers.new(number, sms_url).buy_similar_number).to eq(:new_number)
   end
+
+  it 'feeds the country with an overridden area code to BuysNumbers' do
+    expect(ParsesNumbers).to receive(:new).with(number).and_return(parser = double(:parser))
+    expect(parser).to receive(:parse)
+    expect(parser).to receive(:country).and_return(:country)
+
+    expect(BuysNumbers).to receive(:buy_number).with(:overridden_area_code, :country, :url).and_return(:new_number_with_overridden_area_code)
+
+    expect(BuysSimilarNumbers.new(number, sms_url, :overridden_area_code).buy_similar_number).to eq(:new_number_with_overridden_area_code)
+  end
 end


### PR DESCRIPTION
This makes it easier to create relays on the same installation
without them all being on the same area code.