### PR TITLE
Remove Bourne

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'countries'
 group :test do
   gem 'rspec-rails', '3'
   gem 'mocha', require: false
-  gem 'bourne'
   gem 'cucumber-rails', require: false
   gem 'poltergeist'
   gem 'database_cleaner', '1.5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,8 +30,6 @@ GEM
     addressable (2.4.0)
     arel (5.0.1.20140414130214)
     bcrypt (3.1.7)
-    bourne (1.5.0)
-      mocha (>= 0.13.2, < 0.15)
     bson (4.1.1)
     builder (3.2.2)
     cancan (1.6.10)
@@ -240,7 +238,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bourne
   cancan
   coffee-rails (~> 4)
   countries


### PR DESCRIPTION
It’s long deprecated because of RSpec Mocks. I have a confusing
mix of mocks, it seems! This is broken.